### PR TITLE
feat: EcAuth APIパスを /v1 プレフィックスに更新

### DIFF
--- a/tests/ecauth-login.spec.ts
+++ b/tests/ecauth-login.spec.ts
@@ -40,7 +40,7 @@ test.describe('EcAuth ソーシャルログイン', () => {
     await ecauthButton.click();
 
     // EcAuth IdP の認可エンドポイントにリダイレクトされる
-    await page.waitForURL(/\/authorization/);
+    await page.waitForURL(/\/v1\/authorization/);
 
     // MockIdP のログインフォームが表示される
     await page.waitForURL(new RegExp(mockIdpBaseUrl));


### PR DESCRIPTION
## Summary
- EcAuth 側の API バージョニング導入に伴い、E2Eテストの認可エンドポイントURLパターンを `/v1/authorization` に更新

## Test plan
- [ ] E2E テストがパスすること

Refs: EcAuth/EcAuth#348

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## テスト

* **テスト**
  * 認証フロー検証で、より詳細な認可リダイレクトパスマッチング処理に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->