### PR TITLE
ci: Claude Code Review を導入

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,40 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    # Skip reviews for dependabot PRs
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1.0.140
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: |
+            /code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            Use the repository's CLAUDE.md for guidance on style and conventions.
+            日本語で回答してください。
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          claude_args: '--allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## 概要

EcAuth org 全リポジトリへの **Claude Code Review 横展開**（Refs: EcAuth/EcAuthDocs#86）の一環として、自動 PR レビューワークフローを新規追加します。

## 内容

PR 作成・更新時に `code-review` プラグインで自動レビューを実行する `claude-code-review.yml` を追加。EcAuth#406 で実証した修正済み構成を使用しています:

- `prompt` に `--comment` を付与（プラグインは `--comment` が無いとレビューしても投稿せず終了する）
- `allowed-tools` に `mcp__github_inline_comment__create_inline_comment` を追加（インライン投稿経路 + MCP サーバー起動条件）

レビューは diff ベースで動くため、言語別のビルド/依存 setup ステップは含めていません（最小構成）。

## ⚠️ 前提条件

**`CLAUDE_CODE_OAUTH_TOKEN` を EcAuth org レベル secret に設定**する必要があります（現状は EcAuth repo secret のみ）。未設定の場合、レビュージョブが認証エラーになります。

## 検証

org secret 設定後、本 PR への push（`synchronize`）または別 PR で `claude[bot]`（投稿者は `github-actions[bot]` 名義）のサマリーコメントが投稿されることを確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)